### PR TITLE
FIX: Sort list of job instances

### DIFF
--- a/jberet-core/src/main/resources/sql/jberet-sql.properties
+++ b/jberet-core/src/main/resources/sql/jberet-sql.properties
@@ -1,6 +1,6 @@
 select-all-job-instances = SELECT * FROM JOB_INSTANCE
 count-job-instances-by-job-name = SELECT COUNT(JOBINSTANCEID) FROM JOB_INSTANCE WHERE JOBNAME=?
-select-job-instances-by-job-name = SELECT * FROM JOB_INSTANCE WHERE JOBNAME=?
+select-job-instances-by-job-name = SELECT * FROM JOB_INSTANCE WHERE JOBNAME=? ORDER BY JOBINSTANCEID
 select-job-instance = SELECT * FROM JOB_INSTANCE WHERE JOBINSTANCEID=?
 insert-job-instance = INSERT INTO JOB_INSTANCE(JOBNAME, APPLICATIONNAME) VALUES(?, ?)
 delete-job-instance = DELETE FROM JOB_INSTANCE WHERE JOBINSTANCEID=?


### PR DESCRIPTION
JobOperator.getJobInstances() now returns list according to specification in reverse chronological order